### PR TITLE
sdmdata and models as namedtuple

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,7 @@ SpeciesDistributionModelsMakieExt = "Makie"
 [compat]
 CategoricalDistributions = "0.1.14"
 MLJGLMInterface = "0.3.7"
-Rasters = "0.10.1"
+Rasters = "0.10.1, 0.11"
 StatisticalMeasures = "0.1.5"
 StatsModels = "0.7.3"
 julia = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -47,9 +47,10 @@ julia = "1.9"
 
 [extras]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+MLJModels = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 
 [targets]
-test = ["Distributions", "StableRNGs", "Test", "Makie"]
+test = ["Distributions", "Makie", "MLJModels", "StableRNGs", "Test"]

--- a/ext/SpeciesDistributionModelsMakieExt/SpeciesDistributionModelsMakieExt.jl
+++ b/ext/SpeciesDistributionModelsMakieExt/SpeciesDistributionModelsMakieExt.jl
@@ -1,7 +1,7 @@
 module SpeciesDistributionModelsMakieExt
     using Makie, SpeciesDistributionModels
     import SpeciesDistributionModels as SDM
-    import SpeciesDistributionModels: model_names, machine_evaluations, sdm_machines, data, 
+    import SpeciesDistributionModels: model_keys, machine_evaluations, sdm_machines, data, 
         _conf_mats_from_thresholds
     import SpeciesDistributionModels: interactive_evaluation
     import Statistics, Loess

--- a/ext/SpeciesDistributionModelsMakieExt/plotrecipes.jl
+++ b/ext/SpeciesDistributionModelsMakieExt/plotrecipes.jl
@@ -1,6 +1,6 @@
 function _model_controls!(fig, ensemble)
     toggles = [Makie.Toggle(fig, active = true) for i in 1:Base.length(ensemble)]
-    labels = [Makie.Label(fig, String(key)) for key in SDM.model_names(ensemble)]
+    labels = [Makie.Label(fig, String(key)) for key in SDM.model_keys(ensemble)]
     g = Makie.grid!(hcat(toggles, labels))
     return g, toggles
 end

--- a/ext/SpeciesDistributionModelsMakieExt/plotrecipes.jl
+++ b/ext/SpeciesDistributionModelsMakieExt/plotrecipes.jl
@@ -7,7 +7,7 @@ end
 
 
 function Makie.boxplot(ev::SDMensembleEvaluation, measure::Symbol)
-    modelnames = Base.string.(model_names(ev.ensemble))
+    modelnames = collect(Base.string.(model_keys(ev.ensemble)))
     f = Makie.Figure()
     
     for (i, t) in enumerate((:train, :test))
@@ -55,13 +55,13 @@ function SDM.interactive_evaluation(ensemble; thresholds = 0:0.01:1)
 
     idx_by_model = map(enumerate(ensemble)) do (i, e)
         fill(i, Base.length(e))
-    end |> NamedTuple{Tuple(model_names(ensemble))}
+    end |> NamedTuple{Tuple(model_keys(ensemble))}
 
     n_models = length(idx_by_model)
 
     conf_mats = mapreduce(hcat, ensemble) do gr
         map(gr) do sdm_machine
-            rows = sdm_machine.test_rows
+            rows = SDM.test_rows(sdm_machine)
             y_hat = SDM.MLJBase.predict(sdm_machine.machine; rows)
             y = data(sdm_machine).response[rows]
             _conf_mats_from_thresholds(SDM.MLJBase.pdf.(y_hat, true), y, thresholds)

--- a/src/SpeciesDistributionModels.jl
+++ b/src/SpeciesDistributionModels.jl
@@ -7,7 +7,7 @@ import GLM, PrettyTables, Rasters, EvoTrees, DecisionTree, Shapley, Loess
 using MLJBase: pdf
 using Rasters: Raster, RasterStack, Band
 using ScientificTypesBase: Continuous, OrderedFactor, Multiclass, Count
-using ComputationalResources: CPU1, CPUThreads, AbstractCPU
+using ComputationalResources: CPU1, CPUThreads, AbstractCPU, CPUProcesses
 
 using ScientificTypesBase: Continuous, OrderedFactor, Multiclass, Count
 using StatisticalMeasures: auc, kappa, sensitivity, selectivity, accuracy
@@ -23,12 +23,14 @@ export SDMensemble, predict, sdm, select, machines, machine_keys,
 export auc, kappa, sensitivity, selectivity, accuracy,
     Continuous, OrderedFactor, Multiclass, Count,
     StratifiedCV, CV, Holdout, ResamplingStrategy
-
+#include("learningnetwork.jl")
+include("models.jl")
+include("data_utils.jl")
+    
 include("data_utils.jl")
 include("resample.jl")
 # export stubs for extensions
 export interactive_response_curves, interactive_evaluation
-
 
 include("collinearity.jl")
 include("models.jl")

--- a/src/SpeciesDistributionModels.jl
+++ b/src/SpeciesDistributionModels.jl
@@ -11,9 +11,9 @@ using ComputationalResources: CPU1, CPUThreads, AbstractCPU, CPUProcesses
 
 using ScientificTypesBase: Continuous, OrderedFactor, Multiclass, Count
 using StatisticalMeasures: auc, kappa, sensitivity, selectivity, accuracy
-import MLJBase: StratifiedCV, CV, Holdout, ResamplingStrategy
+import MLJBase: StratifiedCV, CV, Holdout, ResamplingStrategy, Machine, Probabilistic
 
-export SDMensemble, predict, sdm, select, machines, machine_keys,
+export SDMensemble, predict, sdm, sdmdata, select, machines, machine_keys,
     remove_collinear,
     explain, variable_importance, ShapleyValues,
     SDMmachineExplanation, SDMgroupExplanation, SDMensembleExplanation,
@@ -25,8 +25,6 @@ export auc, kappa, sensitivity, selectivity, accuracy,
     StratifiedCV, CV, Holdout, ResamplingStrategy
 #include("learningnetwork.jl")
 include("models.jl")
-include("data_utils.jl")
-    
 include("data_utils.jl")
 include("resample.jl")
 # export stubs for extensions

--- a/src/data_utils.jl
+++ b/src/data_utils.jl
@@ -96,7 +96,7 @@ function _sdmdata(
     y::BooleanCategorical, 
     resampler::MLJBase.ResamplingStrategy, 
 )
-    traintestpairs = MLJBase.train_test_pairs(resampler, eachindex(y), X, y, geometries)
+    traintestpairs = MLJBase.train_test_pairs(resampler, eachindex(y), X, y)
     _sdmdata(X, y, traintestpairs, resampler)
 end
 

--- a/src/data_utils.jl
+++ b/src/data_utils.jl
@@ -1,32 +1,112 @@
-### Miscelanious utilities to deal with data issues such as names, missing values
-
 # Convert a BitArray to a CategoricalArray. Faster and type-stable version of `categorical`
+BooleanCategorical{N} = CategoricalArrays.CategoricalArray{Bool, N, UInt8} where N
 function boolean_categorical(A::BitArray{N}) where N 
-    CategoricalArrays.CategoricalArray{Bool, N, UInt8}(A, levels=[false, true], ordered=false)
+    BooleanCategorical{N}(A, levels=[false, true], ordered=false)
 end
 boolean_categorical(A::AbstractVector{Bool}) = boolean_categorical(BitArray(A))
 
-function _get_predictor_names(p, a)
-    predictors = Base.intersect(Tables.schema(a).names, Tables.schema(p).names)
-    predictors = filter!(!=(:geometry), predictors) # geometry is never a variable
-    length(predictors) > 0 || error("Presence and absence data have no common variable names - can't fit the ensemble.")
-    return predictors
+
+struct SDMdata{K}
+    predictor::NamedTuple
+    response::CategoricalArrays.CategoricalArray
+    geometry::Union{Nothing, Vector}
+    traintestpairs::MLJBase.TrainTestPairs
+    resampler::Union{Nothing, MLJBase.ResamplingStrategy}
+
+    function SDMdata(predictor::P, response, geometry, traintestpairs, resampler) where P<:NamedTuple{K} where K
+        new{K}(predictor, response, geometry, traintestpairs, resampler)
+    end
+end
+
+function Base.show(io::IO, mime::MIME"text/plain", data::SDMdata{K}) where K
+    y = response(data)
+    print("SDMdata object with ")
+    printstyled(sum(y), bold = true)
+    print(" presence points and ")
+    printstyled(length(y) - sum(y), bold = true)
+    print(" absence points. \n \n")
+
+    print("Data is divided into $(nfolds(data)) folds. \n \n")
+
+    printstyled("Predictor variables: \n", bold = true)
+    Base.show(io, mime, MLJBase.schema(predictor(data)))
+
+    if isnothing(geometry(data)) 
+        print("Does not contain geometry data")
+    else
+        print("Also contains geometry data")
+    end
 end
 
 
-function _predictor_response_from_presence_absence(presences, absences, predictors)
+_gettrainrows(d::SDMdata, i) = d.traintestpairs[i][1]
+_gettestrows(d::SDMdata, i) = d.traintestpairs[i][2]
+predictor(d::SDMdata) = d.predictor
+predictorkeys(d::SDMdata{K}) where K = K 
+response(d::SDMdata) = convert(AbstractArray{Bool}, d.response)
+geometry(d::SDMdata) = d.geometry
+traintestpairs(d::SDMdata) = d.traintestpairs
+nfolds(d::SDMdata) = length(d.traintestpairs)
+
+function _sdmdata(presences, absences, resampler, ::Nothing)
+    predictorkeys = Tuple(Base.intersect(Tables.schema(presences).names, Tables.schema(absences).names))
+    length(predictorkeys) > 0 || error("Presence and absence data have no common variable names - can't fit the ensemble.")
+    _sdmdata(presences, absences, resampler, predictorkeys)
+end
+
+function _sdmdata(presences, absences, resampler, predictorkeys::NTuple{<:Any, <:Symbol})
+    X, y = _predictor_response_from_presence_absence(presences, absences, predictorkeys)
+    _sdmdata(X, y, resampler, predictorkeys)
+end
+
+# in case input is a table
+function _sdmdata(X, response::BitVector, resampler, ::Nothing)
+    columns = Tables.columns(X)
+    Tables.rowcount(columns) == length(response) || error("Number of rows in predictors and response do not match")
+    predictorkeys = Tables.columnnames(columns)
+    _sdmdata(X, response, resampler, predictorkeys)
+end
+
+_sdmdata(X::Tables.ColumnTable{K}, y::BitVector, resampler, predictorkeys::NTuple{<:Any, <:Symbol}) where K =
+    if K == predictorkeys
+        _sdmdata(X, boolean_categorical(y), resampler)
+    else
+        _sdmdata(X[predictorkeys], boolean_categorical(y), resampler)
+    end
+
+
+function _sdmdata(
+    X::Tables.ColumnTable, 
+    y::BooleanCategorical, 
+    resampler::MLJBase.ResamplingStrategy, 
+)
+    geometries = :geometry ∈ keys(X) ? Tables.getcolumn(X, :geometry) : nothing
+    X = Base.structdiff(X, NamedTuple{(:geometry,)})
+    traintestpairs = MLJBase.train_test_pairs(resampler, eachindex(y), X, y, geometries)
+    SDMdata(X, y, geometries, traintestpairs, resampler)
+end
+
+function _sdmdata(
+    X::Tables.ColumnTable, 
+    y::BooleanCategorical, 
+    resampler::MLJBase.TrainTestPairs, 
+)
+    SDMdata(X, y, geometries, traintestpairs, nothing)
+end
+
+cpu_backend(threaded) = threaded ? CPUThreads() : CPU1()
+_map(::CPU1) = Base.map
+_map(::CPUThreads) = ThreadsX.map
+
+
+function _predictor_response_from_presence_absence(presences, absences, predictorkeys::NTuple{<:Any, <:Symbol})
     p_columns = Tables.columns(presences)
     a_columns = Tables.columns(absences) 
     n_presence = Tables.rowcount(p_columns)
     n_absence = Tables.rowcount(a_columns)
 
     # merge presence and absence data into one namedtuple of vectors
-    predictor_values = NamedTuple{Tuple(predictors)}([[a_columns[var]; p_columns[var]] for var in predictors])
-    response_values = boolean_categorical([falses(n_absence); trues(n_presence)])
-    return predictor_values, response_values
+    X = NamedTuple{predictorkeys}([[a_columns[var]; p_columns[var]] for var in predictorkeys])
+    y = [falses(n_absence); trues(n_presence)]
+    return (X, y)
 end
-
-
-cpu_backend(threaded) = threaded ? CPUThreads() : CPU1()
-_map(::CPU1) = Base.map
-_map(::CPUThreads) = ThreadsX.map

--- a/src/data_utils.jl
+++ b/src/data_utils.jl
@@ -89,8 +89,10 @@ end
 function _sdmdata(
     X::Tables.ColumnTable, 
     y::BooleanCategorical, 
-    resampler::MLJBase.TrainTestPairs, 
+    traintestpairs::MLJBase.TrainTestPairs, 
 )
+    geometries = :geometry ∈ keys(X) ? Tables.getcolumn(X, :geometry) : nothing
+    X = Base.structdiff(X, NamedTuple{(:geometry,)})
     SDMdata(X, y, geometries, traintestpairs, nothing)
 end
 

--- a/src/ensemble.jl
+++ b/src/ensemble.jl
@@ -1,49 +1,58 @@
 # Machines have 1 machine, plus metadata
-struct SDMmachine
-    machine::MLJBase.Machine
-    predictors::NTuple{<:Any, Symbol}
+struct SDMmachine{M<:MLJBase.Probabilistic} 
+    machine::Machine
+    data::SDMdata
     fold::Int
-    train_rows::Vector{Int}
-    test_rows::Vector{Int}
+
+    SDMmachine(m::Machine{M}, data, fold) where M = new{M}(m, data, fold)
 end
 
 # Groups have multiple machines with identical model and resampler
 struct SDMgroup <: AbstractVector{SDMmachine}
     sdm_machines::Vector{SDMmachine}
     model
-    resampler
-    model_name
+    model_key
 end
 
 # Ensembles have multiple groups with potentially different models and different resamplers, but identical data
-struct SDMensemble <: AbstractVector{SDMgroup}
-    groups::Vector{SDMgroup} # Contains the trained models
+struct SDMensemble{K}
+    groups::NamedTuple{K, <:Tuple{Vararg{SDMgroup}}} # Contains the trained models
+
+    SDMensemble(groups::NamedTuple{K}) where K = new{K}(groups)
 end
+
+function Base.getproperty(ensemble::SDMensemble{K}, s::Symbol) where K
+    if s in K
+        getfield(ensemble.groups, s)
+    else
+        getfield(ensemble, s)
+    end
+end
+
 
 SDMgroupOrEnsemble = Union{SDMgroup, SDMensemble}
 
 # args field stores exactly the data as it is given to the machine
-data(mach::SDMmachine) = (predictor = mach.machine.args[1].data, response = mach.machine.args[2].data)
+data(mach::SDMmachine) = mach.data
 data(s::SDMgroupOrEnsemble) = data(s[1])
-predictors(mach::SDMmachine) = mach.predictors
-predictors(s::SDMgroupOrEnsemble) = predictors(s[1])
+model(g::SDMgroup) = g.model
+models(e::SDMensemble) = map(g -> g.model, groups(e))
+modelkeys(e::SDMensemble{K}) where K = K
 
-
-#Base.getproperty(ensemble::SDMensemble, key::Symbol) = getproperty.(ensemble, key)
-# getproperty directly into models???
-
+Base.iterate(ensemble::SDMensemble) = Base.iterate(ensemble.groups)
+Base.iterate(ensemble::SDMensemble, i) = Base.iterate(ensemble.groups, i)
 Base.getindex(ensemble::SDMensemble, i) = ensemble.groups[i]
 Base.getindex(group::SDMgroup, i) = group.sdm_machines[i]
-Base.size(ensemble::SDMensemble) = size(ensemble.groups)
+Base.length(ensemble::SDMensemble) = Base.length(ensemble.groups)
 Base.size(group::SDMgroup) = size(group.sdm_machines)
 n_machines(ensemble::SDMensemble) = mapreduce(group -> length(group.sdm_machines), +, ensemble)
 
+groups(ensemble::SDMensemble) = ensemble.groups
 machines(group::SDMgroup) = map(m -> m.machine, group)
-
 sdm_machines(group::SDMgroup) = group.sdm_machines
 
 # machine_key generates a unique key for a machine
-machine_keys(group::SDMgroup) = [Symbol("$(group.model_name)_fold$(m.fold)") for m in group]
+machine_keys(group::SDMgroup) = [Symbol("$(group.model_key)_fold$(m.fold)") for m in group]
 
 # A bunch of functions are applied to an ensemble by applying to each group and reducing with vcat
 for f in (:machines, :machine_keys, :sdm_machines)
@@ -98,32 +107,53 @@ function select(ensemble::SDMensemble; machines)
 end
 
 ## Show methods
-function Base.show(io::IO, mime::MIME"text/plain", ensemble::SDMensemble)
-    n_presence = sum(data(ensemble).response .== true)
-    n_absence = sum(data(ensemble).response .== false)
+function Base.show(io::IO, mime::MIME"text/plain", ensemble::SDMensemble{K}) where K
+    d = ensemble[1][1].data#data(ensemble)
+    
+    println(io, "trained SDMensemble, containing $(n_machines(ensemble)) SDMmachines across $(Base.length(ensemble)) SDMgroups \n")
 
-    sc = MLJBase.schema(data(ensemble).predictor)
+    print("Uses the following models: \n")   
+    for k in K
+        modeltype = MLJBase.name(model(ensemble[k]))
+        printstyled(io, k, color = :blue)
+        print(io, " => $modeltype. \n")
+    end
+end
+
+
+#=
+    data = ensemble[1][1].data#data(ensemble)
+    responsedata = response(data)
+
+    n_presence = sum(responsedata .== true)
+    n_absence = sum(length(responsedata) - n_presence)
+
+    sc = MLJBase.schema(predictor(data))
     sci = sc.scitypes
     nam = sc.names
 
-    println(io, "SDMensemble with $(n_machines(ensemble)) machines across $(Base.length(ensemble)) groups")
     println(io, "Occurence data: Presence-Absence with $n_presence presences and $n_absence absences")
     println(io, "Predictors: $(join(["$key ($scitype)" for (key, scitype) in zip(nam, sci)], ", "))")
 
-    m_names = model_names(ensemble)
     resampler_names = MLJBase.name.(getfield.(ensemble.groups, :resampler))
     n_models = Base.length.(ensemble.groups)
-    table_cols = hcat(m_names, resampler_names, n_models)
+    table_cols = hcat(K, resampler_names, n_models)
     header = (["model", "resampler", "machines"])
     PrettyTables.pretty_table(io, table_cols; header = header)
-    
-end
+    =#
+
 
 function Base.show(io::IO, mime::MIME"text/plain", group::SDMgroup)
-    println(io, "SDMgroup with $(Base.length(group)) machines")
-    println(io, "Model $(group.model_name) and resampler $(MLJBase.name(group.resampler))")
+    println(io, "trained SDMgroup, containing $(length(group.sdm_machines)) SDMmachines")
+    println(io, "name: $(group.model_name)")
+    println(io, "model type: $(MLJBase.name(group.model))")
 end
 
+function Base.show(io::IO, mime::MIME"text/plain", mach::SDMmachine)
+    println(io, "trained SDMmachine")
+    println(io, "fold number: $(mach.fold)")
+    println(io, "model type: $(MLJBase.name(mach.machine.model))")
+end
 
 ## Table interface !! Is this still valid?
 Tables.istable(::Type{SDMensemble}) = true
@@ -144,112 +174,52 @@ function _givenames(models::Vector)
     return NamedTuple{Tuple(Symbol.(names))}(models)
 end
 
-function _fit_sdm_model(predictor_values::NamedTuple, response_values, model, fold, train, test, verbosity, cache, scitype_check_level)
+function _fit_sdm_model(data::SDMdata, model::Probabilistic, fold, train, test, verbosity, cache, scitype_check_level)
     scitype_check_level = scitype_check_level * fold == 1
-    mach = MLJBase.machine(model, predictor_values, response_values; cache, scitype_check_level)
+    mach = MLJBase.machine(model, predictor(data), data.response; cache, scitype_check_level)
     MLJBase.fit!(mach; rows = train, verbosity)
-    return SDMmachine(mach, keys(predictor_values), fold, train, test)
+    return SDMmachine(mach, data, fold)
 end
 
 function _fit_sdm_group(
-    predictor_values::NamedTuple, 
-    response_values, 
+    data,
     model, 
-    resampler, 
-    folds,
-    model_name, 
+    model_key,
     verbosity,
     cache,
     scitype_check_level,
     cpu_backend
     )
 
-    machines = _map(cpu_backend)(enumerate(folds)) do (f, (train, test))
-        _fit_sdm_model(predictor_values, response_values, model, f, train, test, verbosity, cache, scitype_check_level)
+    machines = _map(cpu_backend)(enumerate(traintestpairs(data))) do (f, (train, test))
+        _fit_sdm_model(data, model, f, train, test, verbosity, cache, scitype_check_level)
     end
 
-    return SDMgroup(machines, model, resampler, model_name)
+    return SDMgroup(machines, model, model_key)
 
 end
 
 function _sdm(
-    presences,
-    absences,
-    models,
-    resampler,
-    predictors,
-    verbosity,
-    cache, 
-    scitype_check_level,
-    threaded
-)
-    X, y = _predictor_response_from_presence_absence(presences, absences, predictors)
-    # handle geometries separately. In the future, we might use geometries somehow, 
-    # e.g. to add spatial resampling, or define a scatter! recipe.
-    # Right now geometries are not stored/used
-    :geometry ∈ predictors && error("Predictors cannot be called :geometry")
-    #if :geometry ∈ Tables.columnnames(presences) && :geometry ∈ Tables.columnnames(absences)
-    #    geometries = [vcat(Tables.getcolumn(presences, :geometry), Tables.getcolumn(absences, :geometry))]
-    #else
-    #    geometries = nothing
-    #end
-
-    _sdm(X, y, models, resampler, predictors, verbosity, cache, scitype_check_level, threaded)
-end
-
-function _sdm(
-    X, 
-    y::CategoricalArrays.CategoricalArray{Bool},
-    models::Vector{<:MLJBase.Model}, 
-    resampler::MLJBase.ResamplingStrategy,
-    predictors,
+    data::SDMdata,
+    models::NamedTuple{K}, 
     verbosity::Int,
     cache, 
     scitype_check_level,
     threaded::Bool
-)
-    train_test_rows = MLJBase.train_test_pairs(resampler, 1:length(y), y)
-    _fit_sdm_ensemble(X, y; models, resampler, train_test_rows, predictors, verbosity, cache, scitype_check_level, threaded)
-end
-
-function _sdm(
-    X,
-    y::CategoricalArrays.CategoricalArray{Bool},
-    models::Vector{<:MLJBase.Model},
-    train_test_rows::Vector{<:Tuple{AbstractVector{<:Integer}, AbstractVector{<:Integer}}},
-    predictors,
-    verbosity::Int,
-    cache,
-    scitype_check_level,
-    threaded::Bool
-)
-    _fit_sdm_ensemble(X, y; models, resampler = CustomRows(), train_test_rows, predictors, verbosity, cache, scitype_check_level, threaded)
-end
-
-function _fit_sdm_ensemble(X, y; models, resampler, train_test_rows, predictors, verbosity, cache, scitype_check_level, threaded)
-    cols = Tables.columns(X)
-    X_ = NamedTuple{Tuple(predictors)}([Tables.getcolumn(cols, pred) for pred in predictors])
-    _fit_sdm_ensemble(X_, y, models, resampler, train_test_rows, verbosity, cache, scitype_check_level, threaded::Bool)
-end
-
-function _fit_sdm_ensemble(X, y, models, resampler, folds, verbosity, cache, scitype_check_level, threaded::Bool)
-    models = _givenames(models)
+) where K
     backend = cpu_backend(threaded)
-    sdm_groups = _map(backend)(collect(keys(models))) do model_key
+    sdm_groups = _map(backend)(keys(models)) do model_key
         model = models[model_key]
         _fit_sdm_group(
-            X, 
-            y, 
+            data,
             model, 
-            resampler, 
-            folds,
-            model_key, 
+            model_key,
             verbosity,
             cache,
             scitype_check_level,
             backend
         )
-    end
+    end |> NamedTuple{keys(models)}
 
     return SDMensemble(sdm_groups)
 end

--- a/src/ensemble.jl
+++ b/src/ensemble.jl
@@ -61,6 +61,9 @@ end
 
 model_keys(ensemble) = keys(ensemble.groups)
 
+test_rows(mach::SDMmachine) = _gettestrows(data(mach), mach.fold)
+train_rows(mach::SDMmachine) = _gettrainrows(data(mach), mach.fold)
+
 ## Select methods
 # Function to convienently select some models from groups or ensembles
 function select(group::SDMgroup, machine_indices::AbstractVector{<:Integer})

--- a/src/ensemble.jl
+++ b/src/ensemble.jl
@@ -59,7 +59,7 @@ for f in (:machines, :machine_keys, :sdm_machines)
     @eval ($f)(ensemble::SDMensemble) = mapreduce(group -> ($f)(group), vcat, ensemble)
 end
 
-model_names(ensemble) = getfield.(ensemble.groups, :model_name)
+model_keys(ensemble) = keys(ensemble.groups)
 
 ## Select methods
 # Function to convienently select some models from groups or ensembles
@@ -70,8 +70,7 @@ function select(group::SDMgroup, machine_indices::AbstractVector{<:Integer})
         return SDMgroup(
             group.sdm_machines[machine_indices],
             group.model,
-            group.resampler,
-            group.model_name,
+            group.model_key,
         )
     end
 end
@@ -112,7 +111,7 @@ function Base.show(io::IO, mime::MIME"text/plain", ensemble::SDMensemble{K}) whe
     
     println(io, "trained SDMensemble, containing $(n_machines(ensemble)) SDMmachines across $(Base.length(ensemble)) SDMgroups \n")
 
-    print("Uses the following models: \n")   
+    println("Uses the following models:")   
     for k in K
         modeltype = MLJBase.name(model(ensemble[k]))
         printstyled(io, k, color = :blue)
@@ -145,7 +144,7 @@ end
 
 function Base.show(io::IO, mime::MIME"text/plain", group::SDMgroup)
     println(io, "trained SDMgroup, containing $(length(group.sdm_machines)) SDMmachines")
-    println(io, "name: $(group.model_name)")
+    println(io, "name: $(group.model_key)")
     println(io, "model type: $(MLJBase.name(group.model))")
 end
 

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -102,8 +102,8 @@ function Base.show(io::IO, mime::MIME"text/plain", evaluation::SDMgroupEvaluatio
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", evaluation::SDMensembleEvaluation)
-    measures = collect(keys(evaluation[1][1].measures))#collect(keys(measures(evaluation)))
-    models = getfield.(evaluation.ensemble, :model_name)
+    measurekeys = collect(keys(measures(evaluation)))
+    models = collect(modelkeys(evaluation.ensemble))
 
     # get scores from each group
     machine_scores = machine_evaluations.(evaluation)
@@ -111,7 +111,7 @@ function Base.show(io::IO, mime::MIME"text/plain", evaluation::SDMensembleEvalua
     scores = vcat(machine_scores, ensemble_scores)
     # get mean test and train from each group for each measure.
     # then invert to a namedtuple where measures are keys
-    println(io, "$(typeof(evaluation)) with $(length(measures)) performance measures")
+    println(io, "$(typeof(evaluation)) with $(length(measurekeys)) performance measures")
 
     for k in keys(scores[1])
         println(io, string(k))
@@ -171,10 +171,10 @@ function _ev_ydata(sdm_machine, train, test, validation)
     machdata = data(sdm_machine)
     d_y = (;)
     if train 
-        d_y = merge(d_y, (;train = view(machdata.response, sdm_machine.train_rows)))
+        d_y = merge(d_y, (;train = view(machdata.response, _gettrainrows(machdata, sdm_machine.fold))))
     end
     if test
-        d_y = merge(d_y, (;test = view(machdata.response, sdm_machine.test_rows)))
+        d_y = merge(d_y, (;test = view(machdata.response, _gettestrows(machdata, sdm_machine.fold))))
     end
     if !isempty(validation)
         d_y = merge(d_y, (;validation = validation[2]))
@@ -185,17 +185,17 @@ end
 function _ev_predict(sdm_machine::SDMmachine, train, test, validation)
     machdata = data(sdm_machine)
     # set up namedtuple with data/rows, throw out if nothing/false
-    d_X = (;)
+    d_y = (;)
     if train
-        d_X = merge(d_X, (;train = Tables.subset(machdata.predictor, sdm_machine.train_rows)))
+        d_y = merge(d_y, (;train = MLJBase.predict(sdm_machine.machine; rows = _gettrainrows(machdata, sdm_machine.fold))))
     end
     if test
-        d_X = merge(d_X, (;test =  Tables.subset(machdata.predictor, sdm_machine.test_rows)))
+        d_y = merge(d_y, (; test = MLJBase.predict(sdm_machine.machine; rows = _gettestrows(machdata, sdm_machine.fold))))
     end
     if !isempty(validation)
-        d_X = merge(d_X, (;validation = validation[1]))
+        d_y = merge(d_y, (; validation = MLJBase.predict(sdm_machine.machine, validation[1])))
     end
-    map(X -> MLJBase.predict(sdm_machine.machine, X), d_X)
+    return d_y
 end
 
 function _evaluate(sdm_machine::SDMmachine, y_hats::NamedTuple, ys::NamedTuple, measures::NamedTuple)

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -77,23 +77,23 @@ end
 function Base.show(io::IO, mime::MIME"text/plain", evaluation::SDMmachineEvaluation)
     println(io, "SDMmachineEvaluation")
 
-    measures = collect(keys(measures(evaluation)))
+    measure_names = collect(keys(measures(evaluation)))
     sets = evaluation_sets(evaluation)
     scores = map(sets) do s
         round.(getfield.(collect(evaluation.results[s]), :score); digits = 2)
     end
     
-    table_cols = hcat(measures, scores...)
+    table_cols = hcat(measure_names, scores...)
     header = (["measure"; string.(sets)...])
     PrettyTables.pretty_table(io, table_cols; header = header)
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", evaluation::SDMgroupEvaluation)
-    measures = collect(keys(measures(evaluation)))
+    measure_names = collect(keys(measures(evaluation)))
     train_scores, test_scores = machine_evaluations(evaluation)
     folds = getfield.(evaluation.group, :fold)
 
-    println(io, "$(typeof(evaluation)) with $(length(measures)) performance measures")
+    println(io, "$(typeof(evaluation)) with $(length(measure_names)) performance measures")
 
     println(io, "Testing data")
     PrettyTables.pretty_table(io, merge((; fold = folds),  test_scores))

--- a/src/explain/shapley.jl
+++ b/src/explain/shapley.jl
@@ -11,7 +11,7 @@ struct ShapleyValues <: SDMexplainMethod
     algorithm::Shapley.Algorithm
 end
 # Default to MonteCarlo algorithm with 100 samples
-function ShapleyValues(N::Integer; threaded = true, rng = Random.GLOBAL_RNG)
+function ShapleyValues(N::Integer; threaded = false, rng = Random.GLOBAL_RNG)
     resource = threaded ? CPUThreads() : CPU1()
     algorithm = Shapley.MonteCarlo(resource, N, rng)
     ShapleyValues(algorithm)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -21,7 +21,7 @@ function sdm(
     presences,
     absences;
     models,
-    resampler = MLJBase.CV(; nfolds = 5, shuffle = true),
+    resampler = NoResampling(),#MLJBase.CV(; nfolds = 5, shuffle = true),
     predictors = _get_predictor_names(presences, absences),
     verbosity = 0,
     cache = true,

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,5 +1,31 @@
 """
     sdmdata(presences, absences; resampler, predictors)
+    sdmdata(X, y::BitVector; resampler, predictors)
+
+Construct an `SDMdata` object from species `presences` and `absences`. 
+Alternatively, from a table with predictor variables `X` and a `BitVector` `y`, where `false` represents absence and `true` represents presence.
+
+## Keywords
+    `resampler`: The resampling strategy to be used. Should be a `MLJBase.ResamplingStrategy`, or a `Vector` of `Tuple`s with the form `(train, test)`. 
+    Defaults to `NoResampling()`. If `resampler` is a `CV`, `shuffle` is internally set to `true`.
+    `predictors`: a `Tuple` of `Symbols` with the names of the predictor values to be used. By default, all predictor variables in `X`,
+    or all predictor variables in both `presences` and `absences` are used..
+
+## Returns
+An `SDMdata` object containing the data provided. This object can be used to construct an `SDMensemble`.
+
+## Example
+using Rasters, SpeciesDistributionModels
+A = rand(10,10)
+B = rand(10,10)
+st = RasterStack((a=A, b=B), (X, Y); missingval=(a=missing,b=missing))
+
+presence_points = [(1, 1), (2, 2), (3, 3), (4, 4)]
+absence_points = [(5, 5), (6, 6), (7, 7), (8, 8)]
+p = extract(st, presence_points)
+a = extract(st, absence_points)
+mydata = sdmdata(p, a; resampler = CV(nfolds = 5))
+mydata2 = sdmdata([p; a], [trues(4); falses(4)]; resampler = [([1,2],[5,6]), ([3,4], [7,8])])
 """
 
 function sdmdata(
@@ -12,23 +38,27 @@ function sdmdata(
 end
 
 """
-    sdm(presences, absences; models, [resampler], [predictors], [verbosity])
+    sdm(data, models; [resampler], [predictors], [verbosity])
 
-Construct an ensemble with input data specified in `presences` and `absences`.
+Construct an ensemble.
 
-The first input argument is species presences and the second (pseudo-)absences. Both presence and absence data must be Tables-compatible (e.g., a `DataFrame`, a `Vector` of `NamedTuple`, but not an `Array`)
+## Arguments
+`data`: an `SDMdata` object
+`models`: a `NamedTuple` with the models to be used in the ensemble.
 
 ## Keywords
 `models`: a `Vector` of the models to be used in the ensemble. All models must be MLJ-supported Classifiers. 
 For a full list of supported models, see https://alan-turing-institute.github.io/MLJ.jl/stable/model_browser/#Classification
-`resampler`: The resampling strategy to be used of type `MLJBase.ResamplingStrategy`. Defaults to 5-fold cross validation.
 `predictors`: a `Vector` of `Symbols` with the names of the predictor values to be used. By default, all pdf
 `verbosity`: an `Int` value that regulates how much information is printed.
 `cache`: is passed to `MLJBase.machine`. Specify cache=false to prioritize memory management over speed.
 `scitype_check_level`: is passed to `MLJBase.machine`. Specify scitype_check_level=0 to disable scitype checking.
 
 ## Example
-
+using SpeciesDistributionModels, Maxnet, MLJGLMInterface
+mydata = sdmdata(presences, absences; resampler = CV(nfolds = 5))
+models = (maxnet = MaxnetBinaryClassifier(), glm = LinearBinaryClassifier())
+ensemble = sdm(mydata, models)
 """
 function sdm(
     data, models;
@@ -40,19 +70,6 @@ function sdm(
     _sdm(data, models, verbosity, cache, scitype_check_level, threaded)
 end
 
-function sdm(
-    X,
-    y::BitVector;
-    models,
-    resampler = MLJBase.CV(; nfolds = 5, shuffle = true),
-    predictors = Base.filter(!=(:geometry), Tables.schema(X).names),
-    verbosity = 0,
-    cache = true,
-    scitype_check_level = 1,
-    threaded = false
-)
-    _sdm(X, boolean_categorical(y), models, resampler, predictors, verbosity, cache, scitype_check_level, threaded)
-end
 """
     evaluate(x; measures, train = true, test = true, [validation])
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -6,15 +6,16 @@ Construct an `SDMdata` object from species `presences` and `absences`.
 Alternatively, from a table with predictor variables `X` and a `BitVector` `y`, where `false` represents absence and `true` represents presence.
 
 ## Keywords
-    `resampler`: The resampling strategy to be used. Should be a `MLJBase.ResamplingStrategy`, or a `Vector` of `Tuple`s with the form `(train, test)`. 
+- `resampler`: The resampling strategy to be used. Should be a `MLJBase.ResamplingStrategy`, or a `Vector` of `Tuple`s with the form `(train, test)`. 
     Defaults to `NoResampling()`. If `resampler` is a `CV`, `shuffle` is internally set to `true`.
-    `predictors`: a `Tuple` of `Symbols` with the names of the predictor values to be used. By default, all predictor variables in `X`,
-    or all predictor variables in both `presences` and `absences` are used..
+- `predictors`: a `Tuple` of `Symbols` with the names of the predictor values to be used. By default, all predictor variables in `X`,
+   or all predictor variables in both `presences` and `absences` are used..
 
 ## Returns
 An `SDMdata` object containing the data provided. This object can be used to construct an `SDMensemble`.
 
 ## Example
+```
 using Rasters, SpeciesDistributionModels
 A = rand(10,10)
 B = rand(10,10)
@@ -22,12 +23,14 @@ st = RasterStack((a=A, b=B), (X, Y); missingval=(a=missing,b=missing))
 
 presence_points = [(1, 1), (2, 2), (3, 3), (4, 4)]
 absence_points = [(5, 5), (6, 6), (7, 7), (8, 8)]
+
 p = extract(st, presence_points)
 a = extract(st, absence_points)
-mydata = sdmdata(p, a; resampler = CV(nfolds = 5))
-mydata2 = sdmdata([p; a], [trues(4); falses(4)]; resampler = [([1,2],[5,6]), ([3,4], [7,8])])
-"""
 
+mydata = sdmdata(p, a; resampler = CV(nfolds = 2)) # 2-fold cross validation
+mydata2 = sdmdata([p; a], [trues(4); falses(4)]; resampler = [([1,2],[5,6]), ([3,4], [7,8])]) # provide resampling rows
+```
+"""
 function sdmdata(
     presences,
     absences;
@@ -47,18 +50,20 @@ Construct an ensemble.
 `models`: a `NamedTuple` with the models to be used in the ensemble.
 
 ## Keywords
-`models`: a `Vector` of the models to be used in the ensemble. All models must be MLJ-supported Classifiers. 
-For a full list of supported models, see https://alan-turing-institute.github.io/MLJ.jl/stable/model_browser/#Classification
-`predictors`: a `Vector` of `Symbols` with the names of the predictor values to be used. By default, all pdf
-`verbosity`: an `Int` value that regulates how much information is printed.
-`cache`: is passed to `MLJBase.machine`. Specify cache=false to prioritize memory management over speed.
-`scitype_check_level`: is passed to `MLJBase.machine`. Specify scitype_check_level=0 to disable scitype checking.
+- `models`: a `Vector` of the models to be used in the ensemble. All models must be MLJ-supported Classifiers. 
+- For a full list of supported models, see https://alan-turing-institute.github.io/MLJ.jl/stable/model_browser/#Classification
+- `predictors`: a `Vector` of `Symbols` with the names of the predictor values to be used. By default, all pdf
+- `verbosity`: an `Int` value that regulates how much information is printed.
+- `cache`: is passed to `MLJBase.machine`. Specify cache=false to prioritize memory management over speed.
+- `scitype_check_level`: is passed to `MLJBase.machine`. Specify scitype_check_level=0 to disable scitype checking.
 
 ## Example
+```julia
 using SpeciesDistributionModels, Maxnet, MLJGLMInterface
 mydata = sdmdata(presences, absences; resampler = CV(nfolds = 5))
 models = (maxnet = MaxnetBinaryClassifier(), glm = LinearBinaryClassifier())
 ensemble = sdm(mydata, models)
+```
 """
 function sdm(
     data, models;

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -1,9 +1,16 @@
 function _check_data(x, d)
-    @show Tables.istable(d)
     Tables.istable(d) || throw(ArgumentError("data is a $(typeof(d)), wich is not a Tables.jl-compatible table"))
     colnames = Tables.columnnames(Tables.columns(d))
     for key in predictorkeys(data(x))
         key in colnames || throw(ArgumentError("data is missing predictor variable $key"))
+    end
+
+end
+
+function _check_data(x, rs::Rasters.AbstractRasterStack)
+    layernames = Rasters.name(rs)
+    for key in predictorkeys(data(x))
+        key in layernames || throw(ArgumentError("data is missing predictor variable $key"))
     end
 
 end
@@ -89,7 +96,7 @@ _reformat_and_predict(m::SDMmachine, rs::Rasters.AbstractRasterStack, clamp::Boo
     _reformat_and_predict_raster(m, rs, clamp)
 
 function _reformat_and_predict_raster(s::Union{<:SDMensemble, SDMgroup, SDMmachine}, rs::Rasters.AbstractRasterStack, args...)
-    rs_preds = rs[predictors(s)]
+    rs_preds = rs[predictorkeys(data(s))]
     missing_mask = Rasters.boolmask(rs_preds)
     d = rs_preds[missing_mask]
     if any(map(x -> Missing <: eltype(x), rs_preds))

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -76,7 +76,7 @@ function _reformat_and_predict(e::SDMensemble, data, clamp::Bool, reducer::Funct
     if by_group
         # pass the reducer to each group, then combine into a namedtuple
         group_pr = _map(resource)(g -> _reformat_and_predict(g, data, clamp::Bool, reducer, resource), e)
-        NamedTuple{Tuple(model_names(e))}(group_pr)
+        NamedTuple{model_keys(e)}(group_pr)
     else
         # predict without reducing, then apply the reducer
         pr = _map(resource)(g -> _reformat_and_predict(g, data, clamp::Bool, nothing, resource), e)

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -1,4 +1,4 @@
 struct NoResampling <: MLJBase.ResamplingStrategy end
 MLJBase.train_test_pairs(::NoResampling, indices, _)  = [(indices, eltype(indices)[])]## get indices
 
-struct CustomRows end
+struct CustomRows <: MLJBase.ResamplingStrategy end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using SpeciesDistributionModels, MLJBase, Tables
+using SpeciesDistributionModels, MLJBase, MLJModels, Tables
 import SpeciesDistributionModels as SDM
 using StableRNGs, Distributions, Test
 using Makie
@@ -37,10 +37,10 @@ presencedata = (a = rand(rng, n), b = rand(rng, n).^2, c = sqrt.(rand(rng, n)))
     @test evaluation isa SDM.SDMensembleEvaluation
     @test evaluation[1] isa SDM.SDMgroupEvaluation
     @test evaluation[1][1] isa SDM.SDMmachineEvaluation
-    @test evaluation.measures isa NamedTuple
+    @test SDM.measures(evaluation) isa NamedTuple
     mach_evals = SDM.machine_evaluations(evaluation)
     @test mach_evals isa NamedTuple{(:train, :test, :validation)}
-    @test mach_evals.train isa NamedTuple{(keys(evaluation.measures))}
+    @test mach_evals.train isa NamedTuple{(keys(SDM.measures(evaluation)))}
 
     machine_aucs = SDM.machine_evaluations(evaluation).test.auc
 
@@ -50,7 +50,7 @@ presencedata = (a = rand(rng, n), b = rand(rng, n).^2, c = sqrt.(rand(rng, n)))
 
     @test pr2 isa Vector
     @test collect(keys(pr1)) == SDM.machine_keys(ensemble)
-    @test collect(keys(pr3)) == SDM.model_names(ensemble)
+    @test (keys(pr3)) == SDM.model_keys(ensemble)
     eltype(pr3) == Vector{Int64}
 
     @test_throws ArgumentError SDM.predict(ensemble, backgrounddata.a)
@@ -86,21 +86,3 @@ end
     @test remove_collinear(data_with_perfect_collinearity; method = SDM.Pearson(; threshold = 0.65), silent = true) == (:a, )
 end
 
-using SpeciesDistributionModels, MLJBase, Tables
-import SpeciesDistributionModels as SDM
-
-import EvoTrees: EvoTreeClassifier
-    using Statistics
-    using Rasters: RasterStack, Raster
-    xdim = Rasters.X(1:10); ydim = Rasters.Y(1:10)
-    rs = RasterStack([Raster(rand(xdim,ydim)) for i in 1:2]...; name = [:a, :b])
-
-    X = (a = rand(100), b = rand(Float32, 100) .+ 2)
-    y = MLJBase.categorical(rand(Bool, 100))
-    ensemble = SDM.SdmEnsemble(tree = EvoTreeClassifier(), tree2 = EvoTreeClassifier(); reducing_function = mean, cache =true)
-
-    mach = machine(ensemble, X, y)
-    MLJBase.fit!(sp; force = true)
-    MLJBase.predict(sp, rs)
-
-    ev = MLJBase.evaluate!(sp, measure = auc)


### PR DESCRIPTION
some changes to how ensembles are constructed:

- data is now handled by a separate function and stored in a separate type (`sdmdata` and `SDMdata`)
- the `models` argument of `sdm` now needs a `NamedTuple`, and `SDMgroup`s are stored as a `NamedTuple` in an `SDMensemble`.